### PR TITLE
Loosen lita dependency

### DIFF
--- a/lita-ignore-me.gemspec
+++ b/lita-ignore-me.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", ">= 4.6"
+  spec.add_runtime_dependency "lita", "~> 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
R2D8 is still [locked to 4.3.x](https://github.com/tech256/r2d8/blob/master/Gemfile.lock#L15), so I wasn't able to install without upgrading. In this particular case it's nbd to upgrade, but would it help others to loosen the dependency. Assuming your code _is_ actually compatible with Lita 4.x, this would lessen friction for new users.

What do you think?
