### PR TITLE
Add commands to allow user to specify target room

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lita-ignore-me
 
-*lita-ignore-me* is a Lita extension that allows a user to tell the robot that he or she wishes to be ignored unless addressing the robot directly. This means that routes that are triggered that are not commands are not executed.
+**lita-ignore-me** is a Lita extension that allows a user to tell the robot that he or she wishes to be ignored unless addressing the robot directly. This means that routes that are triggered that are not commands are not executed.
 
 ## Installation
 
@@ -12,7 +12,7 @@ spec.add_runtime_dependency "lita-ignore-me"
 
 ## Usage
 
-There is no additional configuration necessary. There are two commands added for a user to manage whether the robot will listen to or ignore that user in the current room: `ignore me` and `listen to me.
+There is no additional configuration necessary. There are two commands added for a user to manage whether the robot will listen to or ignore that user in the current room: `ignore me` and `listen to me`.
 
 Assuming there is some handler that echoes messages that start with 'echo' installed and configured, a conversation might look like this:
 
@@ -20,15 +20,17 @@ Assuming there is some handler that echoes messages that start with 'echo' insta
 Chad: echo I don't like to be echoed.
 Lita: I don't like to be echoed.
 Chad: @Lita: ignore me
-Lita: Okay Chad, I'll ignore you in #channel unless you address me directly.
+Lita: Okay Chad, I'll ignore you in #room unless you address me directly.
 Chad: echo I don't like to be echoed.
 Chad: lita help
 Lita: *prints help*
 Chad: @Lita: listen to me
-Lita: Okay Chad, I'm listening.
+Lita: Okay Chad, I'm listening to you in #room.
 Chad: echo I expect to be echoed.
 Lita: I expect to be echoed.
 ```
+
+You can also request that the robot ignore you or listen to you in a different room by specifying the room name (e.g., `ignore me in #some-room`). In the case of Slack, this allows you to send a message to the robot directly, without the need to clutter the target room with extra messages.
 
 ## License
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,9 +2,12 @@ en:
   lita:
     handlers:
       ignore_me:
-        ignore_help: Instructs the robot to ignore you unless you address it directly.
-        listen_help: Instructs the robot to no longer ignore you.
+        ignore_help: Instructs the robot to ignore you in the current room unless you address it directly.
+        ignore_help_with_room: Instructs the robot to ignore you in the specified room unless you address it directly.
+        listen_help: Instructs the robot to no longer ignore you in the current room.
+        listen_help_with_room: Instructs the robot to no longer ignore you in the specified room.
         ignored: "Okay %{name}, I will ignore you in %{room} unless you address me directly."
         already_ignored: "I'm already ignoring you in %{room}, %{name}."
-        listening: "Okay %{name}, I'm listening."
-        already_listening: "Don't worry %{name}, I'm not ignoring you! :heart:"
+        listening: "Okay %{name}, I'm listening to you in %{room}."
+        already_listening: "Don't worry %{name}, I'm not ignoring you in %{room}! :heart:"
+        sorry_no_room: "I'm sorry %{name}, I'm afraid I can't do that. That room doesn't exist."

--- a/spec/lita/extensions/ignore_me_spec.rb
+++ b/spec/lita/extensions/ignore_me_spec.rb
@@ -9,48 +9,90 @@ describe Echo, lita_handler: true, additional_lita_handlers: Lita::Handlers::Ign
   before :example do
     registry.register_hook(:validate_route, Lita::Extensions::IgnoreMe)
     @bob = Lita::User.create(123, name: "Bob")
+    @room_a = Lita::Room.create_or_update("#room-a", name: "#a")
+    @room_b = Lita::Room.create_or_update("#room-b", name: "#b")
   end
 
   it "echoes a message from bob" do
-    send_message(@message, as: @bob, from: "#a")
+    send_message(@message, as: @bob, from: @room_a)
     expect(replies.first).to eq @echo_response
   end
 
   context "bob is ignored in #a" do
     before do
-      send_command("ignore me", as: @bob, from: "#a")
+      send_command("ignore me", as: @bob, from: @room_a)
     end
 
     it "ignores bob's message in #a" do
-      send_message(@message, as: @bob, from: "#a")
+      send_message(@message, as: @bob, from: @room_a)
       expect(replies.last).not_to eq @echo_message
     end
 
     it "does not ignore alice's message in #a" do
-      send_message(@message, as: Lita::User.create(456, name: "alice"), from: "#a")
+      send_message(@message, as: Lita::User.create(456, name: "alice"), from: @room_a)
       expect(replies.last).to eq @echo_response
     end
 
     it "does not ignore bob's message in #b" do
-      send_message(@message, as: @bob, from: "#b")
+      send_message(@message, as: @bob, from: @room_b)
       expect(replies.last).to eq @echo_response
     end
 
     it "does not ignore bob's command in #a" do
-      send_command(@message, as: @bob, from: "#a")
+      send_command(@message, as: @bob, from: @room_a)
       expect(replies.last).to eq @echo_response
     end
 
     context "bob turns off ignore in #a" do
       before do
-        send_command("listen to me", as: @bob, from: "#a")
+        send_command("listen to me", as: @bob, from: @room_a)
       end
 
       it "does not ignore bob's message in #a" do
-        send_message(@message, as: @bob, from: "#a")
+        send_message(@message, as: @bob, from: @room_a)
         expect(replies.last).to eq @echo_response
       end
     end
 
   end
+
+  context "bob requests to be ignored in #b from #a" do
+
+    before :example do
+      send_command("ignore me in #b", as: @bob, from: @room_a)
+    end
+
+    it "does not ignore bob in #a" do
+      send_message(@message, as: @bob, from: @room_a)
+      expect(replies.last).to eq @echo_response
+    end
+
+    it "ignores bob in #b" do
+      send_message(@message, as: @bob, from: @room_b)
+      expect(replies.last).not_to eq @echo_response
+    end
+
+  end
+
+  context "bob requests to be listened to in #b from #a" do
+
+    before :example do
+      send_command("ignore me", as: @bob, from: @room_a)
+      send_command("ignore me", as: @bob, from: @room_b)
+
+      send_command("listen to me in #b", as: @bob, from: @room_a)
+    end
+
+    it "continues to ignore bob in #a" do
+      send_message(@message, as: @bob, from: @room_a)
+      expect(replies.last).not_to eq @echo_response
+    end
+
+    it "listens to bob in #b" do
+      send_message(@message, as: @bob, from: @room_b)
+      expect(replies.last).to eq @echo_response
+    end
+
+  end
+
 end

--- a/spec/lita/handlers/ignore_me_spec.rb
+++ b/spec/lita/handlers/ignore_me_spec.rb
@@ -3,40 +3,59 @@ require "spec_helper"
 describe Lita::Handlers::IgnoreMe, lita_handler: true do
   before :example do
     @bob = Lita::User.create(123, name: "Bob")
+    @room_a = Lita::Room.create_or_update("#room-a", name: "#a")
+    @room_b = Lita::Room.create_or_update("#room-b", name: "#b")
   end
 
   context "routing" do
     it { is_expected.to route_command("ignore me").to(:ignore_me) }
     it { is_expected.to route_command("IGNORE ME").to(:ignore_me) }
+    it { is_expected.to route_command("ignore me in #some-room").to(:ignore_me_in_room) }
 
     it { is_expected.to route_command("listen to me").to(:listen_to_me) }
     it { is_expected.to route_command("LISTEN TO ME").to(:listen_to_me) }
+    it { is_expected.to route_command("listen to me in #some-room").to(:listen_to_me_in_room) }
   end
 
   context "when bob is not being ignored" do
     it "tells bob it will ignore him upon request" do
-      send_command("ignore me", as: @bob, from: "#a")
+      send_command("ignore me", as: @bob, from: @room_a)
       expect(replies.last).to eq "Okay Bob, I will ignore you in #a unless you address me directly."
     end
 
+    it "tells bob it will ignore him when he asks to be ignored in a different room" do
+      send_command("ignore me in #b", as: @bob, from: @room_a)
+      expect(replies.last).to eq "Okay Bob, I will ignore you in #b unless you address me directly."
+    end
+
+    it "tells bob it cannot find a non-existent room when he requests to be ignored" do
+      send_command("ignore me in #non-room", as: @bob, from: @room_a)
+      expect(replies.last).to eq "I'm sorry Bob, I'm afraid I can't do that. That room doesn't exist."
+    end
+
     it "tells bob it is not ignoring him if he requests that the robot listen" do
-      send_command("listen to me", as: @bob, from: "#a")
-      expect(replies.last).to eq "Don't worry Bob, I'm not ignoring you! :heart:"
+      send_command("listen to me", as: @bob, from: @room_a)
+      expect(replies.last).to eq "Don't worry Bob, I'm not ignoring you in #a! :heart:"
+    end
+
+    it "tells bob it cannot find a non-existent room when he requests the robot listen" do
+      send_command("listen to me in #non-existent", as: @bob, from: @room_a)
+      expect(replies.last).to eq "I'm sorry Bob, I'm afraid I can't do that. That room doesn't exist."
     end
   end
 
   context "when bob is being ignored in #a" do
     before :example do
-      send_command("ignore me", as: @bob, from: "#a")
+      send_command("ignore me", as: @bob, from: @room_a)
     end
 
     it "tells bob he is no longer ignoring him upon request" do
-      send_command("listen to me", as: @bob, from: "#a")
-      expect(replies.last).to eq "Okay Bob, I'm listening."
+      send_command("listen to me", as: @bob, from: @room_a)
+      expect(replies.last).to eq "Okay Bob, I'm listening to you in #a."
     end
 
     it "tells bob it is already ignoring him if he requests to be ignored" do
-      send_command("ignore me", as: @bob, from: "#a")
+      send_command("ignore me", as: @bob, from: @room_a)
       expect(replies.last).to eq "I'm already ignoring you in #a, Bob."
     end
   end


### PR DESCRIPTION
This commit introduces a new variant on the 'ignore me' and 'listen to
me' commands by adding support for specifying the room in the command
(e.g., 'ignore me in #some-room'). In adapters where the user can speak
with the robot in a "room" directly - like the Slack adapter - this will
allow the user to privately set ignore and listen rules.

Fixes #2
